### PR TITLE
Fix build on nightly

### DIFF
--- a/examples/basic_atlas.rs
+++ b/examples/basic_atlas.rs
@@ -5,7 +5,7 @@ fn main() {
     let bytes = include_bytes!("Gudea-Regular.ttf");
     let font = load_font_from_bytes(bytes.to_vec());
     let chars = font_atlas::ASCII.iter().cloned().chain(font_atlas::ASCII.iter().cloned());
-    let (_, bitmap) = font.make_atlas(chars, 20.0, 1, 128, 128);
+    let (_, bitmap, _) = font.make_atlas(chars, 20.0, 1, 128, 128);
     for line in bitmap.lines() {
         print!("{:03} ", line.len());
         for &pixel in line {

--- a/src/rasterize/mod.rs
+++ b/src/rasterize/mod.rs
@@ -107,14 +107,14 @@ impl glyph_packer::Buffer2d for Bitmap {
     fn get(&self, x: u32, y: u32) -> Option<Self::Pixel> {
         let x = x as usize;
         let y = y as usize;
-        let width = self.width() as usize();
+        let width = self.width() as usize;
         self.bytes.get(x + width * y).cloned()
     }
 
     fn set(&mut self, x: u32, y: u32, val: Self::Pixel) {
         let x = x as usize;
         let y = y as usize;
-        let width = self.width() as usize();
+        let width = self.width() as usize;
         if let Some(p) = self.bytes.get_mut(x + width * y) {
             *p = val;
         }


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/42238 for more information about the issue).
